### PR TITLE
Sorting recipes by upvotes and ascending or descending order

### DIFF
--- a/server/controllers/recipes.controller.js
+++ b/server/controllers/recipes.controller.js
@@ -28,7 +28,21 @@ export default class RecipesController {
    * @memberof RecipesController
    */
   index(req, res) {
-    return res.sendSuccessResponse({ recipes: this.database.recipes }, 200);
+    const { recipes } = this.database;
+
+    if (req.query.sort) {
+      if (req.query.sort === 'upvotes') {
+        if (req.query.order) {
+          if (req.query.order === 'desc') {
+            recipes.sort((recipe1, recipe2) => recipe1.upvotes < recipe2.upvotes);
+          } else {
+            recipes.sort((recipe1, recipe2) => recipe1.upvotes > recipe2.upvotes);
+          }
+        }
+      }
+    }
+
+    return res.sendSuccessResponse({ recipes }, 200);
   }
   /**
    * Store a new recipe into the database

--- a/server/database/db.js
+++ b/server/database/db.js
@@ -44,7 +44,7 @@ export default [
     ],
     "createdAt": "2016-09-10 00:00:00",
     "updatedAt": "2017-10-10 00:00:00",
-    "upvotes": 11,
+    "upvotes": 112,
     "downvotes": 3323,
     "favorites": 12
   },
@@ -68,7 +68,7 @@ export default [
     ],
     "createdAt": "2016-09-10 00:00:00",
     "updatedAt": "2017-10-10 00:00:00",
-    "upvotes": 11,
+    "upvotes": 2901,
     "downvotes": 3323,
     "favorites": 12
   },
@@ -93,7 +93,7 @@ export default [
     ],
     "createdAt": "2015-09-10 11:20:51",
     "updatedAt": "2017-10-11 01:00:02",
-    "upvotes": 11,
+    "upvotes": 783,
     "downvotes": 3323,
     "favorites": 12
   }

--- a/test/feature/recipes.spec.js
+++ b/test/feature/recipes.spec.js
@@ -13,7 +13,6 @@ describe('/recipes', () => {
         .end((error, response) => {
           expect(response).to.have.status(200);
           const res = response.body;
-          console.log(res);
           
           expect(res.data.recipes).to.not.be.undefined;
           expect(Array.isArray(res.data.recipes)).to.be.true;


### PR DESCRIPTION
#### What does this PR do

- Adds sorting to the recipes end point

#### Description of Task to be completed

- When the correct queries are passed, it can sort the recipes by upvotes, in descending or ascending order

#### How should this be manually tested

- Make a request to the `api/v1/recipes?sort=upvotes&order=desc` to see the recipes ordered in descending order of votes

#### What are the relevant pivotal tracker stories

#152063441

#### Screenshots